### PR TITLE
depend on `image` with `default-features = false`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["external-ffi-bindings"]
 
 [dependencies]
 libwebp-sys = "0.2.0"
-image = { version = "^0.23.13", optional = true }
+image = { version = "^0.23.13", default-features = false, optional = true }
 
 [features]
 default = ["img"]


### PR DESCRIPTION
This crate doesn't make use of any of the codecs in `image`, which can
be individually enabled with cargo features, and are all enabled by
default. Setting default-features=false allows applications that
depend on `webp` and `image` to select exactly what `image` features
they need.

Fixes #4