### PR TITLE
Update image to v0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["external-ffi-bindings"]
 
 [dependencies]
 libwebp-sys = "0.4.2"
-image = { version = "^0.23.13", default-features = false, optional = true }
+image = { version = "^0.24.0", default-features = false, optional = true }
 
 [features]
 default = ["img"]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -31,8 +31,6 @@ impl<'a> Encoder<'a> {
             DynamicImage::ImageRgba8(image) => {
                 Ok(Self::from_rgba(image.as_ref(), image.width(), image.height()))
             }
-            DynamicImage::ImageBgr8(_) => { Err("Unimplemented") }
-            DynamicImage::ImageBgra8(_) => { Err("Unimplemented") }
             _ => { Err("Unimplemented") }
         }
     }


### PR DESCRIPTION
I noticed `image v0.24.0` was  just released with support for lossless webp decoding. Upgrading the dependency here would unblock [Zola](https://github.com/getzola/zola) from supporting resizing more images (as I discovered in https://github.com/jaredforth/webp/issues/7#issuecomment-987693204).