### PR TITLE
added is_alpha getter to WebPImage

### DIFF
--- a/src/shared.rs
+++ b/src/shared.rs
@@ -83,6 +83,10 @@ impl WebPImage {
     pub fn height(&self) -> u32 {
         self.height
     }
+
+    pub fn is_alpha(&self) -> bool {
+        self.layout.is_alpha()
+    }
 }
 
 impl Deref for WebPImage {


### PR DESCRIPTION
I want to know if my WebPImage has an alpha channel or not.