### PR TITLE
chore: Bump libwebp-sys and crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webp"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Jared Forth <jaredforthdev@gmail.com>"]
 edition = "2018"
 
@@ -15,7 +15,7 @@ keywords = ["image", "webp", "conversion"]
 categories = ["external-ffi-bindings"]
 
 [dependencies]
-libwebp-sys = "0.9.1"
+libwebp-sys = "0.9.3"
 image = { version = "^0.24.0", default-features = false, optional = true }
 
 [features]


### PR DESCRIPTION
There's a new webp CVE that's been resolved in the latest version of `libwebp-sys`: [RUSTSEC-2023-0061](https://rustsec.org/advisories/RUSTSEC-2023-0061)

Also bumps the crate version from `0.2.5` to `0.2.6` for a new release.