### PR TITLE
feat: consume frame after added, for reducing memory usage

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -2,41 +2,48 @@ use webp::AnimEncoder;
 use webp::AnimFrame;
 use webp::WebPConfig;
 fn main() {
-    let width = 32u32;
-    let height = 32u32;
-    fn dumy_image(width: u32, height: u32, color: [u8; 4]) -> Vec<u8> {
+    let width = 512u32;
+    let height = 512u32;
+
+    fn dumy_image(width: u32, height: u32, frame: u32, total_frames: u32) -> Vec<u8> {
         let mut pixels = Vec::with_capacity(width as usize * height as usize * 4);
-        for _ in 0..(width * height) {
-            pixels.push(color[0]); //red
-            pixels.push(color[1]); //green
-            pixels.push(color[2]); //blue
-            pixels.push(color[3]); //alpha
+        for x in 0..width {
+            for y in 0..height {
+                let normalized_frame = frame as f32 / total_frames as f32;
+                let normalized_x = x as f32 / width as f32;
+                let normalized_y = y as f32 / height as f32;
+
+                let r = ((normalized_frame + normalized_x + normalized_y) % 1.0 * 255.0) as u8;
+                let g =
+                    ((normalized_frame + normalized_x + normalized_y + 0.33) % 1.0 * 255.0) as u8;
+                let b =
+                    ((normalized_frame + normalized_x + normalized_y + 0.67) % 1.0 * 255.0) as u8;
+
+                pixels.push(r);
+                pixels.push(g);
+                pixels.push(b);
+                pixels.push(255); // alpha channel, fully opaque
+            }
         }
         pixels
     }
+
     let mut config = WebPConfig::new().unwrap();
     config.lossless = 1;
     config.alpha_compression = 0;
-    config.quality = 75f32;
+    config.quality = 100f32;
     let mut encoder = AnimEncoder::new(width as u32, height as u32, &config);
     encoder.set_bgcolor([255, 0, 0, 255]);
-    encoder.set_loop_count(3);
-    let mut time_ms = 1000;
+    encoder.set_loop_count(0);
+    let mut time_ms = 0;
 
-    let v = dumy_image(width, height, [255, 0, 0, 255]);
-    encoder.add_frame(AnimFrame::from_rgba(&v, width, height, time_ms));
-    time_ms += 750;
-
-    let v = dumy_image(width, height, [0, 255, 0, 255]);
-    encoder.add_frame(AnimFrame::from_rgba(&v, width, height, time_ms));
-    time_ms += 500;
-
-    let v = dumy_image(width, height, [0, 0, 255, 255]);
-    encoder.add_frame(AnimFrame::from_rgba(&v, width, height, time_ms));
-    time_ms += 250;
-
-    let v = dumy_image(width, height, [0, 0, 0, 0]);
-    encoder.add_frame(AnimFrame::from_rgba(&v, width, height, time_ms));
+    for i in 0..120 {
+        let image = dumy_image(width, height, i, 120);
+        encoder
+            .add_frame(AnimFrame::from_rgba(&image, width, height, time_ms))
+            .unwrap();
+        time_ms += 17;
+    }
 
     let webp = encoder.encode();
     let output_path = std::path::Path::new("assets")


### PR DESCRIPTION
If we encode a WebP animation with many frames, caching all frames into a Vec and then adding them all to the encoder at once is not a good approach. This could potentially lead to excessive memory usage.

It is better to consume  each frames after they are added.

## BREAKING API
`AnimEncoder::add_frame()` should return a Result.