### PR TITLE
refactor: correctly specify static lifetime for returned error

### DIFF
--- a/src/animation_encoder.rs
+++ b/src/animation_encoder.rs
@@ -31,7 +31,7 @@ impl<'a> AnimFrame<'a> {
         }
     }
     #[cfg(feature = "img")]
-    pub fn from_image(image: &'a DynamicImage, timestamp: i32) -> Result<Self, &'a str> {
+    pub fn from_image(image: &'a DynamicImage, timestamp: i32) -> Result<Self, &'static str> {
         match image {
             DynamicImage::ImageLuma8(_) => Err("Unimplemented"),
             DynamicImage::ImageLumaA8(_) => Err("Unimplemented"),

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -21,7 +21,7 @@ impl<'a> Encoder<'a> {
 
     #[cfg(feature = "img")]
     /// Creates a new encoder from the given image.
-    pub fn from_image(image: &'a DynamicImage) -> Result<Self, &'a str> {
+    pub fn from_image(image: &'a DynamicImage) -> Result<Self, &'static str> {
         match image {
             DynamicImage::ImageLuma8(_) => Err("Unimplemented"),
             DynamicImage::ImageLumaA8(_) => Err("Unimplemented"),


### PR DESCRIPTION
This previously made it very difficult to bubble up returned errors